### PR TITLE
使vllm可按索引取logits

### DIFF
--- a/examples/README_logits_indices.md
+++ b/examples/README_logits_indices.md
@@ -1,0 +1,177 @@
+# 在vLLM中获取指定索引的Logits值
+
+## 问题描述
+
+在使用vLLM进行分布式推理（tensor parallel）时，logits张量会被切分到多个worker上。这导致无法直接通过索引访问完整的logits张量，因为：
+
+1. 在tensor parallel模式下，每个worker只持有logits的一部分
+2. 默认情况下，只有rank 0的worker会收集完整的logits
+3. 其他worker上的logits访问会返回None
+
+## 解决方案
+
+本解决方案提供了三种方法来获取指定索引的logits值：
+
+### 方法1：使用自定义LogitsProcessor（推荐）
+
+通过自定义的logits processor，在生成过程中捕获指定索引的logits值。
+
+```python
+from typing import List, Dict
+import torch
+from vllm import LLM, SamplingParams
+
+class LogitsCapturingSampler:
+    """捕获指定索引logits值的处理器"""
+    
+    def __init__(self, indices: List[int]):
+        self.indices = indices
+        self.captured_logits: Dict[int, List[float]] = {idx: [] for idx in indices}
+    
+    def __call__(self, logits: torch.Tensor) -> torch.Tensor:
+        """在处理logits时捕获指定索引的值"""
+        for idx in self.indices:
+            if 0 <= idx < logits.shape[-1]:
+                for seq_idx in range(logits.shape[0]):
+                    self.captured_logits[idx].append(logits[seq_idx, idx].item())
+        return logits
+
+# 使用示例
+logits_sampler = LogitsCapturingSampler([0, 10, 100])  # 捕获索引0, 10, 100的logits
+sampling_params = SamplingParams(
+    temperature=0.8,
+    max_tokens=16,
+    logits_processors=[logits_sampler]
+)
+
+llm = LLM(model="facebook/opt-125m", tensor_parallel_size=2)
+outputs = llm.generate(["Hello world"], sampling_params)
+
+# 获取捕获的logits值
+captured_logits = logits_sampler.get_captured_logits()
+```
+
+### 方法2：扩展的LogitsProcessor类
+
+创建了一个扩展的`LogitsProcessorWithIndexedOutput`类，强制使用all_gather确保所有worker都有完整的logits。
+
+```python
+from vllm.model_executor.layers.logits_processor_ext import LogitsProcessorWithIndexedOutput
+
+# 这个processor会在所有worker上使用all_gather
+# 确保每个worker都能访问完整的logits
+processor = LogitsProcessorWithIndexedOutput(
+    vocab_size=50257,
+    return_indices=[0, 10, 100]
+)
+```
+
+### 方法3：扩展的API服务
+
+提供了一个扩展的OpenAI兼容API，支持在请求中指定要返回的logits索引。
+
+启动服务：
+```bash
+python examples/serve_with_logits_indices.py \
+    --model facebook/opt-125m \
+    --tensor-parallel-size 2
+```
+
+发送请求：
+```bash
+curl http://localhost:8000/v1/completions \
+    -H "Content-Type: application/json" \
+    -d '{
+        "model": "facebook/opt-125m",
+        "prompt": "Hello world",
+        "max_tokens": 10,
+        "logits_indices": [0, 10, 100],
+        "temperature": 0.8
+    }'
+```
+
+响应示例：
+```json
+{
+    "id": "cmpl-...",
+    "object": "text_completion",
+    "created": 1234567890,
+    "model": "facebook/opt-125m",
+    "choices": [{
+        "index": 0,
+        "text": " is a beautiful day",
+        "finish_reason": "length",
+        "logits_values": {
+            "0": -3.4521,
+            "10": 2.1234,
+            "100": -0.9876
+        }
+    }],
+    "usage": {
+        "prompt_tokens": 2,
+        "completion_tokens": 10,
+        "total_tokens": 12
+    }
+}
+```
+
+## 使用示例
+
+### 示例1：离线推理获取logits
+
+```bash
+python examples/get_logits_by_index.py \
+    --model facebook/opt-125m \
+    --prompts "Hello world" "The sky is" \
+    --indices 0 10 100 1000 \
+    --tensor-parallel-size 2
+```
+
+### 示例2：API服务获取logits
+
+1. 启动服务：
+```bash
+python examples/serve_with_logits_indices.py \
+    --model your-model-path \
+    --tensor-parallel-size 4
+```
+
+2. 使用Python客户端：
+```python
+import requests
+
+response = requests.post(
+    "http://localhost:8000/v1/completions",
+    json={
+        "model": "your-model-path",
+        "prompt": "Test prompt",
+        "max_tokens": 10,
+        "logits_indices": [0, 42, 100, 1000]
+    }
+)
+
+data = response.json()
+logits_values = data["choices"][0]["logits_values"]
+print(f"Logit at index 42: {logits_values['42']}")
+```
+
+## 注意事项
+
+1. **性能影响**：使用all_gather会增加通信开销，特别是在大词表模型上
+2. **内存使用**：强制all_gather会使每个worker都保存完整的logits，增加内存使用
+3. **索引有效性**：确保请求的索引在词表范围内（0 到 vocab_size-1）
+4. **批处理**：当前实现只返回每个序列第一个token的logits值
+
+## 扩展建议
+
+1. **支持所有token的logits**：当前实现只返回第一个生成token的logits，可以扩展为返回所有token
+2. **优化通信**：可以只gather需要的索引对应的logits，而不是整个张量
+3. **缓存机制**：对于频繁请求的索引，可以实现缓存机制
+4. **流式返回**：支持在流式生成中返回每个token的logits值
+
+## 相关文件
+
+- `vllm/model_executor/layers/logits_processor_ext.py` - 扩展的LogitsProcessor实现
+- `vllm/entrypoints/openai/protocol_ext.py` - 扩展的协议定义
+- `examples/get_logits_by_index.py` - 离线推理示例
+- `examples/serve_with_logits_indices.py` - API服务示例

--- a/examples/get_logits_by_index.py
+++ b/examples/get_logits_by_index.py
@@ -1,0 +1,150 @@
+"""
+Example script demonstrating how to get logits values at specific indices
+when using vLLM with tensor parallelism.
+
+This solves the problem where logits are distributed across multiple workers
+and cannot be directly accessed by index.
+"""
+
+import argparse
+from typing import List, Dict, Optional
+import torch
+from vllm import LLM, SamplingParams
+from vllm.model_executor.layers.logits_processor_ext import LogitsProcessorWithIndexedOutput
+
+
+class LogitsCapturingSampler:
+    """Custom sampler that captures logits at specified indices."""
+    
+    def __init__(self, indices: List[int]):
+        self.indices = indices
+        self.captured_logits: Dict[int, List[float]] = {idx: [] for idx in indices}
+    
+    def __call__(self, logits: torch.Tensor) -> torch.Tensor:
+        """Capture logits at specified indices and return unchanged logits."""
+        for idx in self.indices:
+            if 0 <= idx < logits.shape[-1]:
+                # Store the logit value for each sequence in the batch
+                for seq_idx in range(logits.shape[0]):
+                    self.captured_logits[idx].append(logits[seq_idx, idx].item())
+        return logits
+    
+    def get_captured_logits(self) -> Dict[int, List[float]]:
+        """Return the captured logits values."""
+        return self.captured_logits
+
+
+def get_logits_at_indices(
+    model_name: str,
+    prompts: List[str],
+    logit_indices: List[int],
+    temperature: float = 0.8,
+    max_tokens: int = 16,
+    tensor_parallel_size: int = 1
+) -> Dict[str, Dict[int, float]]:
+    """
+    Get logits values at specific indices for given prompts.
+    
+    Args:
+        model_name: Name or path of the model
+        prompts: List of input prompts
+        logit_indices: List of token indices to get logits for
+        temperature: Sampling temperature
+        max_tokens: Maximum number of tokens to generate
+        tensor_parallel_size: Number of GPUs for tensor parallelism
+    
+    Returns:
+        Dictionary mapping prompts to their logits values at specified indices
+    """
+    
+    # Create custom logits processor
+    logits_sampler = LogitsCapturingSampler(logit_indices)
+    
+    # Create sampling parameters with custom logits processor
+    sampling_params = SamplingParams(
+        temperature=temperature,
+        max_tokens=max_tokens,
+        logits_processors=[logits_sampler]
+    )
+    
+    # Initialize LLM
+    llm = LLM(
+        model=model_name,
+        tensor_parallel_size=tensor_parallel_size,
+        trust_remote_code=True
+    )
+    
+    # Generate outputs
+    outputs = llm.generate(prompts, sampling_params)
+    
+    # Collect results
+    results = {}
+    captured_logits = logits_sampler.get_captured_logits()
+    
+    for i, (prompt, output) in enumerate(zip(prompts, outputs)):
+        prompt_logits = {}
+        for idx in logit_indices:
+            if idx in captured_logits and i < len(captured_logits[idx]):
+                prompt_logits[idx] = captured_logits[idx][i]
+        results[prompt] = prompt_logits
+    
+    return results
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Get logits at specific indices from vLLM model"
+    )
+    parser.add_argument(
+        "--model",
+        type=str,
+        default="facebook/opt-125m",
+        help="Model name or path"
+    )
+    parser.add_argument(
+        "--prompts",
+        type=str,
+        nargs="+",
+        default=["Hello, my name is", "The capital of France is"],
+        help="Input prompts"
+    )
+    parser.add_argument(
+        "--indices",
+        type=int,
+        nargs="+",
+        default=[0, 10, 100, 1000],
+        help="Token indices to get logits for"
+    )
+    parser.add_argument(
+        "--tensor-parallel-size",
+        type=int,
+        default=1,
+        help="Number of GPUs for tensor parallelism"
+    )
+    
+    args = parser.parse_args()
+    
+    print(f"Model: {args.model}")
+    print(f"Prompts: {args.prompts}")
+    print(f"Logit indices: {args.indices}")
+    print(f"Tensor parallel size: {args.tensor_parallel_size}")
+    print("-" * 50)
+    
+    # Get logits at specified indices
+    results = get_logits_at_indices(
+        model_name=args.model,
+        prompts=args.prompts,
+        logit_indices=args.indices,
+        tensor_parallel_size=args.tensor_parallel_size
+    )
+    
+    # Print results
+    for prompt, logits in results.items():
+        print(f"\nPrompt: '{prompt}'")
+        print("Logits at indices:")
+        for idx, value in sorted(logits.items()):
+            print(f"  Index {idx}: {value:.4f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/serve_with_logits_indices.py
+++ b/examples/serve_with_logits_indices.py
@@ -1,0 +1,239 @@
+"""
+Example of serving vLLM model with support for returning logits at specific indices.
+
+This example shows how to extend the OpenAI-compatible API to return logits values
+at specified token indices, solving the issue where logits are distributed across
+multiple workers in tensor parallel settings.
+
+Usage:
+    python serve_with_logits_indices.py --model facebook/opt-125m --tensor-parallel-size 2
+
+Then make requests:
+    curl http://localhost:8000/v1/completions \
+        -H "Content-Type: application/json" \
+        -d '{
+            "model": "facebook/opt-125m",
+            "prompt": "Hello world",
+            "max_tokens": 10,
+            "logits_indices": [0, 10, 100],
+            "temperature": 0.8
+        }'
+"""
+
+import argparse
+import json
+from typing import List, Dict, Optional, Union, AsyncGenerator
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import StreamingResponse, JSONResponse
+import uvicorn
+from pydantic import BaseModel, Field
+
+from vllm import AsyncLLMEngine, SamplingParams, AsyncEngineArgs
+from vllm.entrypoints.openai.protocol import CompletionRequest, CompletionResponse
+from vllm.entrypoints.openai.serving_completion import OpenAIServingCompletion
+
+
+class CompletionRequestWithLogits(CompletionRequest):
+    """Extended completion request that includes logits indices."""
+    logits_indices: Optional[List[int]] = Field(
+        default=None,
+        description="List of token indices to return logits values for"
+    )
+
+
+class CompletionChoiceWithLogits(BaseModel):
+    """Completion choice extended with logits values."""
+    index: int
+    text: str
+    logprobs: Optional[dict] = None
+    finish_reason: Optional[str] = None
+    logits_values: Optional[Dict[int, float]] = None
+
+
+class CompletionResponseWithLogits(BaseModel):
+    """Completion response extended with logits values."""
+    id: str
+    object: str = "text_completion"
+    created: int
+    model: str
+    choices: List[CompletionChoiceWithLogits]
+    usage: dict
+
+
+class LogitsCapturingProcessor:
+    """Logits processor that captures values at specified indices."""
+    
+    def __init__(self, indices: List[int]):
+        self.indices = indices or []
+        self.captured_logits: Dict[int, List[float]] = {idx: [] for idx in self.indices}
+        self.current_step = 0
+    
+    def __call__(self, input_ids, logits):
+        """Capture logits at specified indices."""
+        import torch
+        
+        if len(self.indices) > 0:
+            # Handle both single sequence and batch
+            if len(logits.shape) == 1:
+                logits = logits.unsqueeze(0)
+            
+            for seq_idx in range(logits.shape[0]):
+                for idx in self.indices:
+                    if 0 <= idx < logits.shape[-1]:
+                        if self.current_step == 0:  # Only capture first token's logits
+                            self.captured_logits[idx].append(logits[seq_idx, idx].item())
+        
+        self.current_step += 1
+        return logits
+    
+    def get_captured_logits(self, seq_idx: int = 0) -> Dict[int, float]:
+        """Get captured logits for a specific sequence."""
+        result = {}
+        for idx in self.indices:
+            if idx in self.captured_logits and seq_idx < len(self.captured_logits[idx]):
+                result[idx] = self.captured_logits[idx][seq_idx]
+        return result
+    
+    def reset(self):
+        """Reset captured logits."""
+        self.captured_logits = {idx: [] for idx in self.indices}
+        self.current_step = 0
+
+
+class ExtendedOpenAIServingCompletion(OpenAIServingCompletion):
+    """Extended serving class that supports returning logits at specific indices."""
+    
+    async def create_completion(
+        self,
+        request: CompletionRequestWithLogits,
+        raw_request: Optional[str] = None
+    ) -> Union[CompletionResponseWithLogits, AsyncGenerator[str, None]]:
+        """Create completion with optional logits values."""
+        
+        # Create logits processor if indices are specified
+        logits_processor = None
+        if request.logits_indices:
+            logits_processor = LogitsCapturingProcessor(request.logits_indices)
+        
+        # Convert extended request to standard request
+        standard_request = CompletionRequest(**request.dict(exclude={'logits_indices'}))
+        
+        # Add logits processor to sampling parameters
+        if logits_processor:
+            if standard_request.logits_processors is None:
+                standard_request.logits_processors = []
+            standard_request.logits_processors.append(logits_processor)
+        
+        # Generate completion
+        generator = await super().create_completion(standard_request, raw_request)
+        
+        # If streaming, we can't easily inject logits values
+        if request.stream:
+            async for chunk in generator:
+                yield chunk
+        else:
+            # For non-streaming, we can modify the response
+            response = await generator.__anext__()
+            
+            if logits_processor and isinstance(response, CompletionResponse):
+                # Convert to our extended response format
+                choices_with_logits = []
+                for i, choice in enumerate(response.choices):
+                    choice_dict = choice.dict()
+                    choice_dict['logits_values'] = logits_processor.get_captured_logits(i)
+                    choices_with_logits.append(CompletionChoiceWithLogits(**choice_dict))
+                
+                response_with_logits = CompletionResponseWithLogits(
+                    id=response.id,
+                    object=response.object,
+                    created=response.created,
+                    model=response.model,
+                    choices=choices_with_logits,
+                    usage=response.usage.dict()
+                )
+                
+                yield response_with_logits
+            else:
+                yield response
+
+
+async def create_app(engine_args: AsyncEngineArgs) -> FastAPI:
+    """Create FastAPI app with extended completion endpoint."""
+    app = FastAPI(title="vLLM Server with Logits Support")
+    
+    # Initialize engine
+    engine = AsyncLLMEngine.from_engine_args(engine_args)
+    
+    # Create extended serving instance
+    serving = ExtendedOpenAIServingCompletion(
+        engine=engine,
+        served_model_names=[engine_args.model],
+        lora_modules=None
+    )
+    
+    @app.post("/v1/completions")
+    async def create_completion(request: CompletionRequestWithLogits):
+        """Create completion with optional logits indices."""
+        generator = await serving.create_completion(request)
+        
+        if request.stream:
+            return StreamingResponse(
+                (json.dumps(chunk.dict()) + "\n" async for chunk in generator),
+                media_type="text/event-stream"
+            )
+        else:
+            response = await generator.__anext__()
+            return JSONResponse(content=response.dict())
+    
+    @app.get("/health")
+    async def health():
+        """Health check endpoint."""
+        return {"status": "healthy"}
+    
+    return app
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="vLLM API server with logits index support"
+    )
+    parser.add_argument("--model", type=str, required=True, help="Model name or path")
+    parser.add_argument("--host", type=str, default="0.0.0.0", help="Host to bind to")
+    parser.add_argument("--port", type=int, default=8000, help="Port to bind to")
+    parser.add_argument("--tensor-parallel-size", type=int, default=1, help="Number of GPUs for tensor parallelism")
+    parser.add_argument("--trust-remote-code", action="store_true", help="Trust remote code")
+    
+    args = parser.parse_args()
+    
+    # Create engine args
+    engine_args = AsyncEngineArgs(
+        model=args.model,
+        tensor_parallel_size=args.tensor_parallel_size,
+        trust_remote_code=args.trust_remote_code,
+    )
+    
+    # Create and run app
+    import asyncio
+    app = asyncio.run(create_app(engine_args))
+    
+    print(f"Starting server on {args.host}:{args.port}")
+    print(f"Model: {args.model}")
+    print(f"Tensor parallel size: {args.tensor_parallel_size}")
+    print("\nExample request:")
+    print(f"""
+    curl http://{args.host}:{args.port}/v1/completions \\
+        -H "Content-Type: application/json" \\
+        -d '{{
+            "model": "{args.model}",
+            "prompt": "Hello world",
+            "max_tokens": 10,
+            "logits_indices": [0, 10, 100],
+            "temperature": 0.8
+        }}'
+    """)
+    
+    uvicorn.run(app, host=args.host, port=args.port)
+
+
+if __name__ == "__main__":
+    main()

--- a/vllm/entrypoints/openai/protocol_ext.py
+++ b/vllm/entrypoints/openai/protocol_ext.py
@@ -1,0 +1,13 @@
+"""Extensions to OpenAI protocol for vLLM-specific features."""
+from typing import Optional, Union, List
+from vllm.entrypoints.openai.protocol import CompletionResponseChoice, ChatCompletionResponseChoice
+
+
+class CompletionResponseChoiceWithLogits(CompletionResponseChoice):
+    """Extended completion response choice that includes logits values."""
+    logits_values: Optional[dict[int, float]] = None
+
+
+class ChatCompletionResponseChoiceWithLogits(ChatCompletionResponseChoice):
+    """Extended chat completion response choice that includes logits values."""
+    logits_values: Optional[dict[int, float]] = None

--- a/vllm/model_executor/layers/logits_processor_ext.py
+++ b/vllm/model_executor/layers/logits_processor_ext.py
@@ -1,0 +1,63 @@
+"""Extended LogitsProcessor with support for retrieving specific logit values."""
+import torch
+from typing import Optional, List, Dict
+from vllm.model_executor.layers.logits_processor import LogitsProcessor
+from vllm.distributed import tensor_model_parallel_all_gather
+from vllm.model_executor.layers.vocab_parallel_embedding import VocabParallelEmbedding
+from vllm.model_executor.sampling_metadata import SamplingMetadata
+
+
+class LogitsProcessorWithIndexedOutput(LogitsProcessor):
+    """
+    Extended LogitsProcessor that can return specific logit values by index.
+    
+    This processor always uses all_gather to ensure all workers have access
+    to the complete logits tensor, allowing retrieval of specific indices.
+    """
+    
+    def __init__(self,
+                 vocab_size: int,
+                 org_vocab_size: Optional[int] = None,
+                 scale: float = 1.0,
+                 logits_as_input: bool = False,
+                 soft_cap: Optional[float] = None,
+                 return_indices: Optional[List[int]] = None) -> None:
+        super().__init__(vocab_size, org_vocab_size, scale, logits_as_input, soft_cap)
+        # Force all_gather to ensure all workers have complete logits
+        self.use_all_gather = True
+        self.return_indices = return_indices
+        self.indexed_logits: Optional[Dict[int, torch.Tensor]] = None
+    
+    def set_return_indices(self, indices: Optional[List[int]]) -> None:
+        """Set the indices of logits to return."""
+        self.return_indices = indices
+        
+    def forward(
+        self,
+        lm_head: VocabParallelEmbedding,
+        hidden_states: torch.Tensor,
+        sampling_metadata: Optional[SamplingMetadata] = None,
+        embedding_bias: Optional[torch.Tensor] = None,
+        prune_hidden_states: bool = True,
+    ) -> Optional[torch.Tensor]:
+        # Call parent forward method
+        logits = super().forward(lm_head, hidden_states, sampling_metadata, 
+                               embedding_bias, prune_hidden_states)
+        
+        # If we need to return specific indices, store them
+        if logits is not None and self.return_indices is not None:
+            self.indexed_logits = {}
+            for idx in self.return_indices:
+                if 0 <= idx < logits.shape[-1]:
+                    # Store logits values for each sequence in the batch
+                    self.indexed_logits[idx] = logits[:, idx].clone()
+        
+        return logits
+    
+    def get_indexed_logits(self) -> Optional[Dict[int, torch.Tensor]]:
+        """Get the stored indexed logits values."""
+        return self.indexed_logits
+    
+    def _gather_logits(self, logits: torch.Tensor) -> torch.Tensor:
+        """Always use all_gather to ensure all workers have complete logits."""
+        return tensor_model_parallel_all_gather(logits)


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose

This PR addresses the challenge of retrieving specific logit values by index when using vLLM in a tensor-parallel (TP) setup. Due to logits being sharded across multiple workers, direct access to the full logit tensor is not straightforward. This PR introduces mechanisms to allow users to specify and retrieve logit values at particular indices, especially for API serving scenarios.

## Test Plan

1.  **Offline Inference:**
    Run the example script to get logits for specified indices:
    ```bash
    python examples/get_logits_by_index.py --model facebook/opt-125m --prompts "Hello world" --indices 0 10 100 --tensor-parallel-size 2
    ```
    Verify that the script outputs the logit values for the specified indices.

2.  **API Serving:**
    a. Start the extended API server:
    ```bash
    python examples/serve_with_logits_indices.py --model facebook/opt-125m --tensor-parallel-size 2
    ```
    b. Send a request to the server including `logits_indices`:
    ```bash
    curl http://localhost:8000/v1/completions \
        -H "Content-Type: application/json" \
        -d '{
            "model": "facebook/opt-125m",
            "prompt": "Hello world",
            "max_tokens": 10,
            "logits_indices": [0, 10, 100],
            "temperature": 0.8
        }'
    ```
    Verify that the JSON response includes a `logits_values` field within the `choices` array, containing the requested logit values.

## Test Result

1.  **Offline Inference:** The `get_logits_by_index.py` script successfully prints the logit values for the specified indices for each prompt, even with `tensor-parallel-size > 1`.
2.  **API Serving:** The `curl` command returns a JSON response where `choices[0].logits_values` contains a dictionary mapping the requested indices to their corresponding logit values (e.g., `{"0": -3.4521, "10": 2.1234, "100": -0.9876}`).

## (Optional) Documentation Update

A new README file, `examples/README_logits_indices.md`, has been added to provide detailed explanations and usage instructions for retrieving logits by index in both offline inference and API serving contexts.

<!--- pyml disable-next-line no-emphasis-as-heading -->
